### PR TITLE
Mobile gray bar fix.

### DIFF
--- a/themes/bootstrap/css/style.css
+++ b/themes/bootstrap/css/style.css
@@ -1018,8 +1018,11 @@ nav{
 @media (max-width: 992px){
   .col-md-8.about-main h1{
     font-size: 1.5em;
-    padding-top: 60px !important;
-    margin-bottom: 0;
+    /*padding-top: 60px !important;
+    margin-bottom: 0;*/
+    padding: 0 !important;
+    margin-bottom: 10px;
+    padding-left: 14% !important;
 }
   .col-md-4.about-img{
     display: none;
@@ -1030,7 +1033,7 @@ nav{
     height: 100%;
     position: relative;
     padding: 0;
-    margin-top: -40px;
+    top: 40px;
     overflow-y:auto; 
     padding-bottom:30px; 
   }


### PR DESCRIPTION
Fixed the gray bar appearing at the bottom of the About page 2 screen
on mobile, and made the header styling consistent with page 1 (as much
as possible).
