### PR TITLE
Reduced jumbo header on Act page.

### DIFF
--- a/themes/bootstrap/css/style.css
+++ b/themes/bootstrap/css/style.css
@@ -1192,6 +1192,12 @@ nav{
 	    margin-top: 30px;
 	}
 }
+@media (max-width: 768px) and (orientation:portrait){
+  .act h1 {
+    font-size: 2.75em;
+    margin: 0;
+  }
+}
 @media (max-width: 1024px) and (orientation:landscape){
   .body-copy {
     line-height: inherit;


### PR DESCRIPTION
Tested on Chrome emulation.

Bug text: “act header is huge on act page on tablet portrait. ”
