### PR TITLE
Colored in excess background on Stories page.

### DIFF
--- a/themes/bootstrap/css/style.css
+++ b/themes/bootstrap/css/style.css
@@ -1220,6 +1220,11 @@ nav{
     padding-top: 5px;
   }
 }
+@media (max-width: 1024px){
+  #stories .page1-container {
+    background-color: rgba(0,0,0,0.8);
+  }
+}
 @media (max-width: 768px){
 	.col-md-12.visible-xs.act {
 		background-color: rgba(0,0,0, 0.8);


### PR DESCRIPTION
Tested on Chrome emulation.

Bug text: “grey bar at bottom of stories page on tablets/ mobile”
