### PR TITLE
Fixed gray bars at image bottoms.

### DIFF
--- a/themes/bootstrap/css/style.css
+++ b/themes/bootstrap/css/style.css
@@ -1197,6 +1197,10 @@ nav{
     font-size: 2.75em;
     margin: 0;
   }
+  .col-sm-4.about-left,
+  .col-sm-3.about-right {
+    top: 5px;
+  }
 }
 @media (max-width: 1024px) and (orientation:landscape){
   .body-copy {


### PR DESCRIPTION
Tested on Chrome emulation.

Bug text: “images on about page 1 have grey lines on bottom on portrait”
