### PR TITLE
"Join" and "Donate" pop-ups scroll vert. when windows are short.

### DIFF
--- a/themes/bootstrap/css/style.css
+++ b/themes/bootstrap/css/style.css
@@ -305,6 +305,7 @@ nav{
 .story-container {
 	position: absolute;
 	bottom: 0;
+  margin-left: 60px;
 }
 
 .story-title {


### PR DESCRIPTION
Tested on Chrome emulation. Now elements that would otherwise be outside
the bounds of the container will be inside.
